### PR TITLE
Fix: Correct ticket image height and add aria-label to FlipButton

### DIFF
--- a/components/City.tsx
+++ b/components/City.tsx
@@ -41,10 +41,10 @@ const TicketImage = ({ ticketImage, cityName, side = "front" }: ImageProps) => (
   <Image
     src={side === "front" ? ticketImage.front : ticketImage.back}
     alt={`${cityName} transport ticket ${side}`}
-    width={350}
-    height={0}
+    width={350} // Keep width, next/image might use it for initial sizing or aspect ratio calculation before styles apply
+    // height={0} // REMOVE THIS LINE
     style={{
-      maxHeight: "450px", //Max height of the ticket image
+      maxHeight: "450px",
       width: "auto",
       height: "auto",
       objectFit: "contain",

--- a/components/ImageGallery.tsx
+++ b/components/ImageGallery.tsx
@@ -78,6 +78,7 @@ export default function ImageGallery() {
           <FlipButton
             onClick={() => toggleFlipRef.current?.()}
             className="bottom-4 right-4"
+  aria-label="Flip ticket" // ADD THIS LINE
           />
         </div>
       </div>


### PR DESCRIPTION
- Removed `height={0}` from the `Image` component in `TicketImage` (in `components/City.tsx`). This was causing incorrect image rendering. The existing CSS styles for `height: 'auto'`, `width: 'auto'`, and `objectFit: 'contain'` will now correctly manage the image dimensions and aspect ratio.
- Added `aria-label="Flip ticket"` to the `FlipButton` component in `components/ImageGallery.tsx` to improve accessibility.